### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Periscope-Like floating hearts animation.
 
 Example showing how to recreate the floating hearts animation on Periscope.
 
-#Demo
+# Demo
 ![Demo](https://github.com/saidmarouf/FloatingHearts/blob/master/hearts.gif)
 
-#Info
+# Info
 Requires Xcode 7<br />
 This is an example and not yet provided as an installable Pod. Mostly implemented as a fun exercise.<br />
 
-#To-Do
+# To-Do
 Refactor for better customizabilty.
 Provide as a reusable Pod
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
